### PR TITLE
feat: progressive streaming with cache-first token-by-token completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,25 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Log request metadata to the FIM output channel. Does not log API keys."
+                },
+                "FIM.streamEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable progressive streaming: show completions as soon as the first chunk of tokens arrives, then continue fetching more in the background for the next keystroke."
+                },
+                "FIM.streamTokens": {
+                    "type": "number",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 64,
+                    "description": "How many tokens to collect before showing the first inline completion chunk. Lower values make completions appear faster. The rest of the stream is cached for the next keystroke."
+                },
+                "FIM.streamCacheTtlMs": {
+                    "type": "number",
+                    "default": 30000,
+                    "minimum": 1000,
+                    "maximum": 120000,
+                    "description": "How long (in ms) to keep cached stream continuations. When you type again within this window, the next tokens are served from cache without an API call."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 
-// import * as https from 'https';
-// const agent = new https.Agent({ keepAlive: true });
-
 const SECRET_KEY = 'FIM.apiKey';
 const output = vscode.window.createOutputChannel('FIM');
+
+/* ------------------------------------------------------------------ */
+/*  Types & Config                                                     */
+/* ------------------------------------------------------------------ */
 
 interface ExtensionConfig {
     enabled: boolean;
@@ -24,15 +25,109 @@ interface ExtensionConfig {
     debounceMs: number;
     stop: string[];
     logRequests: boolean;
+    streamEnabled: boolean;
+    streamTokens: number;
+    streamCacheTtlMs: number;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stream Cache – progressive multi-chunk completion                  */
+/* ------------------------------------------------------------------ */
+
+interface StreamCacheEntry {
+    /** The full text accumulated so far (or complete). */
+    fullText: string;
+    /** How many characters were already returned to VS Code. */
+    returnedChars: number;
+    /** Whether the upstream stream has finished. */
+    isComplete: boolean;
+    /** Timestamp of last activity (for TTL eviction). */
+    lastAccess: number;
+    /** Resolves when the stream finishes (or aborts). Used by waiters. */
+    donePromise: Promise<void>;
+    /** Allow external code to signal done. */
+    resolveDone: () => void;
+}
+
+const streamCache = new Map<string, StreamCacheEntry>();
+
+/** Periodically evict stale cache entries. */
+setInterval(() => {
+    const now = Date.now();
+    const cfg = getConfig();
+    for (const [key, entry] of streamCache) {
+        if (now - entry.lastAccess > cfg.streamCacheTtlMs) {
+            streamCache.delete(key);
+        }
+    }
+}, 10_000);
+
+/**
+ * Build a cache key that is stable enough to survive small edits.
+ * We key on document + offset + model + a "fuzzy" hash of the last 256 chars
+ * of the prefix (the most relevant context for FIM).  This way when the user
+ * types a few characters the cache can still serve the continuation.
+ */
+function makeCacheKey(
+    doc: vscode.TextDocument,
+    offset: number,
+    prefix: string,
+    model: string,
+): string {
+    // Only the tail of the prefix matters for FIM – the model mainly looks at
+    // nearby context.  Hashing the last 256 chars keeps the key stable across
+    // small edits while still invalidating when the immediate context changes.
+    const tail = prefix.length > 256 ? prefix.slice(prefix.length - 256) : prefix;
+    const tailHash = simpleHash(tail);
+    return `${doc.uri.toString()}|${offset}|${tailHash}|${model}`;
+}
+
+/**
+ * Search the stream cache for entries at *nearby* offsets (within ±16 chars).
+ * When the user types a few characters we can often reuse a stream that was
+ * started for a slightly earlier cursor position.
+ */
+function findNearbyCacheEntry(
+    doc: vscode.TextDocument,
+    offset: number,
+    prefix: string,
+    model: string,
+): StreamCacheEntry | undefined {
+    // First try exact match.
+    const exactKey = makeCacheKey(doc, offset, prefix, model);
+    const exact = streamCache.get(exactKey);
+    if (exact) return exact;
+
+    // Then search nearby offsets (look-back first – user usually types forward).
+    for (let delta = -1; delta >= -16; delta--) {
+        const nearbyOffset = offset + delta;
+        if (nearbyOffset < 0) continue;
+        const nearbyKey = makeCacheKey(doc, nearbyOffset, prefix, model);
+        const entry = streamCache.get(nearbyKey);
+        if (entry && entry.fullText.length > entry.returnedChars) {
+            // Found a nearby entry with unconsumed text.
+            // Re-key it to the current offset so subsequent lookups hit directly.
+            streamCache.delete(nearbyKey);
+            entry.lastAccess = Date.now();
+            streamCache.set(exactKey, entry);
+            return entry;
+        }
+    }
+
+    return undefined;
+}
+
+function simpleHash(s: string): number {
+    let hash = 0;
+    for (let i = 0; i < s.length; i++) {
+        const ch = s.charCodeAt(i);
+        hash = ((hash << 5) - hash + ch) | 0;
+    }
+    return hash;
 }
 
 interface CompletionChoice {
     text?: string;
-}
-
-interface CompletionResponse {
-    choices?: CompletionChoice[];
-    error?: unknown;
 }
 
 function getConfig(): ExtensionConfig {
@@ -55,6 +150,9 @@ function getConfig(): ExtensionConfig {
         debounceMs: cfg.get<number>('debounceMs', 200),
         stop: cfg.get<string[]>('stop', []),
         logRequests: cfg.get<boolean>('logRequests', false),
+        streamEnabled: cfg.get<boolean>('streamEnabled', true),
+        streamTokens: cfg.get<number>('streamTokens', 5),
+        streamCacheTtlMs: cfg.get<number>('streamCacheTtlMs', 30000),
     };
 }
 
@@ -127,13 +225,33 @@ function cleanupCompletion(text: string): string {
 
 
 
-async function requestFim(
+/* ------------------------------------------------------------------ */
+/*  Streaming FIM request with early-return for progressive display    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Start a streaming FIM request.
+ *
+ * When `cfg.streamEnabled` is true:
+ *   1. The function returns as soon as `cfg.streamTokens` tokens have been
+ *      collected, giving VS Code an *instant* inline completion.
+ *   2. The remainder of the stream is read in the background and stored in
+ *      `streamCache`.  On the very next keystroke the provider will serve the
+ *      next chunk from cache – **no API call needed**.
+ *
+ * Returns:
+ *   - `text`: the text to show right now (may be partial)
+ *   - `isComplete`: whether the full stream has been consumed
+ *   - The cache entry is populated / updated for subsequent calls.
+ */
+async function requestFimStream(
     apiKey: string,
     cfg: ExtensionConfig,
     prefix: string,
     suffix: string,
+    cacheKey: string,
     token: vscode.CancellationToken,
-): Promise<string | undefined> {
+): Promise<{ text: string; isComplete: boolean } | undefined> {
     const url = joinUrl(cfg.baseUrl, cfg.completionsPath);
     const payload: Record<string, unknown> = {
         model: cfg.model,
@@ -156,10 +274,32 @@ async function requestFim(
     const timeout = setTimeout(() => controller.abort(), cfg.requestTimeoutMs);
     const cancelDisposable = token.onCancellationRequested(() => controller.abort());
 
+    // Create the cache entry *before* we start so concurrent keystrokes see it.
+    let resolveDone: () => void;
+    const donePromise = new Promise<void>(r => { resolveDone = r; });
+
+    const entry: StreamCacheEntry = {
+        fullText: '',
+        returnedChars: 0,
+        isComplete: false,
+        lastAccess: Date.now(),
+        donePromise,
+        resolveDone: resolveDone!,
+    };
+    streamCache.set(cacheKey, entry);
+
+    // We'll collect enough characters to approximate cfg.streamTokens tokens.
+    // A rough heuristic: avg token ≈ 4 chars for code.
+    const streamCharTarget = cfg.streamEnabled
+        ? cfg.streamTokens * 4
+        : Number.MAX_SAFE_INTEGER;
+
     try {
         const start = Date.now();
         if (cfg.logRequests) {
-            output.appendLine(`[req] model=${cfg.model} prefix=${prefix.length}suffix=${suffix.length} max_tokens=${cfg.maxTokens}`);
+            output.appendLine(
+                `[req] model=${cfg.model} prefix_len=${prefix.length} suffix_len=${suffix.length} max_tokens=${cfg.maxTokens} stream_tokens=${cfg.streamTokens}`,
+            );
         }
 
         const response = await fetch(url, {
@@ -170,33 +310,41 @@ async function requestFim(
             },
             body: JSON.stringify(payload),
             signal: controller.signal,
-            // agent, // reuse connection
         });
 
         if (!response.ok) {
             const errText = await response.text();
             output.appendLine(`[http ${response.status}] ${errText}`);
+            streamCache.delete(cacheKey);
             return undefined;
         }
 
-        // Read the stream
         const reader = response.body?.getReader();
         if (!reader) {
+            streamCache.delete(cacheKey);
             return undefined;
         }
 
         const decoder = new TextDecoder();
-        let fullText = '';
         let firstToken = true;
+        let earlyResolved = false;
 
+        // ---- inner read loop -------------------------------------------------
         while (true) {
             if (token.isCancellationRequested) {
                 reader.cancel();
+                streamCache.delete(cacheKey);
                 return undefined;
             }
 
             const { done, value } = await reader.read();
-            if (done) break;
+            if (done) {
+                // Stream finished naturally.
+                entry.isComplete = true;
+                entry.lastAccess = Date.now();
+                entry.resolveDone();
+                break;
+            }
 
             const chunk = decoder.decode(value, { stream: true });
             const lines = chunk.split('\n');
@@ -204,7 +352,12 @@ async function requestFim(
             for (const line of lines) {
                 if (!line.startsWith('data: ')) continue;
                 const data = line.slice(6).trim();
-                if (data === '[DONE]') break;
+                if (data === '[DONE]') {
+                    entry.isComplete = true;
+                    entry.lastAccess = Date.now();
+                    entry.resolveDone();
+                    break;
+                }
 
                 try {
                     const parsed = JSON.parse(data);
@@ -217,26 +370,78 @@ async function requestFim(
                                 output.appendLine(`[stream] TTFB: ${ttfb}ms`);
                             }
                         }
-                        fullText += text;
+                        entry.fullText += text;
+                        entry.lastAccess = Date.now();
                     }
-                } catch { }
+                } catch { /* ignore malformed SSE lines */ }
+            }
+
+            // ---- early return: we have enough characters for the first chunk ---
+            if (
+                !earlyResolved &&
+                cfg.streamEnabled &&
+                entry.fullText.length >= streamCharTarget
+            ) {
+                earlyResolved = true;
+                const cleaned = cleanupCompletion(entry.fullText);
+                entry.returnedChars = cleaned.length;
+
+                // Return the first chunk NOW. The rest continues in background.
+                const elapsed = Date.now() - start;
+                if (cfg.logRequests) {
+                    output.appendLine(
+                        `[stream] early-return after ${elapsed}ms, ${cleaned.length} chars (target ~${cfg.streamTokens} tokens)`,
+                    );
+                }
+
+                // Don't break – keep reading in background.
+                // We return this partial result but the loop continues.
+                const partialResult = cleaned.trim().length > 0 ? cleaned : entry.fullText;
+
+                // Continue the loop in the background, return early.
+                // We use a microtask to keep the reader alive after returning.
+                (async () => {
+                    try {
+                        await continueReadingInBackground(
+                            reader, decoder, entry, cfg, token, start
+                        );
+                    } catch { /* reader already closed or cancelled */ }
+                })();
+
+                return {
+                    text: partialResult,
+                    isComplete: false,
+                };
             }
         }
 
+        // ---- stream ended (or early-return not enabled) ----------------------
         const total = Date.now() - start;
         if (cfg.logRequests) {
-            output.appendLine(`[req] completed in ${total}ms, response length: ${fullText.length} chars`);
+            output.appendLine(
+                `[req] completed in ${total}ms, response length: ${entry.fullText.length} chars`,
+            );
         }
 
-        if (token.isCancellationRequested) return undefined;
+        if (token.isCancellationRequested) {
+            streamCache.delete(cacheKey);
+            return undefined;
+        }
 
-        const cleaned = cleanupCompletion(fullText);
-        return cleaned.trim().length > 0 ? cleaned : undefined;
+        const cleaned = cleanupCompletion(entry.fullText);
+        entry.fullText = cleaned;
+        entry.returnedChars = cleaned.length;
+        entry.isComplete = true;
+        entry.resolveDone();
 
+        return cleaned.trim().length > 0
+            ? { text: cleaned, isComplete: true }
+            : undefined;
     } catch (err) {
         if (!token.isCancellationRequested) {
             output.appendLine(`[err] ${String(err)}`);
         }
+        streamCache.delete(cacheKey);
         return undefined;
     } finally {
         clearTimeout(timeout);
@@ -244,11 +449,93 @@ async function requestFim(
     }
 }
 
+/**
+ * Continue reading the SSE stream in the background after the early return.
+ * Updates the cache entry in-place so the next `provideInlineCompletionItems`
+ * call can serve the continuation from cache.
+ */
+async function continueReadingInBackground(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    decoder: TextDecoder,
+    entry: StreamCacheEntry,
+    cfg: ExtensionConfig,
+    token: vscode.CancellationToken,
+    start: number,
+): Promise<void> {
+    try {
+        while (true) {
+            if (token.isCancellationRequested) {
+                reader.cancel();
+                break;
+            }
+
+            const { done, value } = await reader.read();
+            if (done) {
+                entry.isComplete = true;
+                entry.lastAccess = Date.now();
+                entry.resolveDone();
+                break;
+            }
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (!line.startsWith('data: ')) continue;
+                const data = line.slice(6).trim();
+                if (data === '[DONE]') {
+                    entry.isComplete = true;
+                    entry.lastAccess = Date.now();
+                    entry.resolveDone();
+                    return;
+                }
+
+                try {
+                    const parsed = JSON.parse(data);
+                    const text = parsed.choices?.[0]?.text;
+                    if (text) {
+                        entry.fullText += text;
+                        entry.lastAccess = Date.now();
+                    }
+                } catch { /* ignore */ }
+            }
+        }
+    } catch {
+        // Reader cancelled or network error – cache what we have.
+        entry.isComplete = true;
+        entry.resolveDone();
+    } finally {
+        if (cfg.logRequests) {
+            const total = Date.now() - start;
+            output.appendLine(
+                `[stream-bg] finished in ${total}ms, total chars: ${entry.fullText.length}`,
+            );
+        }
+    }
+}
+
+/** Legacy wrapper used by the test command. */
+async function requestFim(
+    apiKey: string,
+    cfg: ExtensionConfig,
+    prefix: string,
+    suffix: string,
+    token: vscode.CancellationToken,
+): Promise<string | undefined> {
+    const cacheKey = `test|${Date.now()}|${Math.random()}`;
+    // Force full streaming (no early return) for test requests.
+    const testCfg = { ...cfg, streamEnabled: false };
+    const result = await requestFimStream(apiKey, testCfg, prefix, suffix, cacheKey, token);
+    return result?.text;
+}
+
+
+/* ------------------------------------------------------------------ */
+/*  Inline Completion Provider                                         */
+/* ------------------------------------------------------------------ */
 
 function buildProvider(context: vscode.ExtensionContext): vscode.InlineCompletionItemProvider {
     let warnedMissingKey = false;
-    let lastCacheKey = '';
-    let lastCompletion: string | undefined;
 
     return {
         async provideInlineCompletionItems(document, position, _inlineContext, token) {
@@ -282,23 +569,90 @@ function buildProvider(context: vscode.ExtensionContext): vscode.InlineCompletio
                 return undefined;
             }
 
-            const cacheKey = [document.uri.toString(), document.version, offset, cfg.model, cfg.maxTokens].join('|');
-            if (cacheKey === lastCacheKey && lastCompletion) {
-                return new vscode.InlineCompletionList([
-                    new vscode.InlineCompletionItem(lastCompletion, new vscode.Range(position, position)),
-                ]);
+            // ── cache-first strategy ──────────────────────────────────────
+            const cacheKey = makeCacheKey(document, offset, prefix, cfg.model);
+
+            // 1) Check if we have a cached stream continuation (exact or nearby offset).
+            const cached = findNearbyCacheEntry(document, offset, prefix, cfg.model);
+            if (cached && cached.returnedChars < cached.fullText.length) {
+                // There is new text the user hasn't seen yet – serve it instantly!
+                cached.lastAccess = Date.now();
+                const available = cached.fullText.slice(cached.returnedChars);
+
+                // Only serve a chunk of ~streamTokens chars to keep the
+                // token-by-token feel (don't dump all 64 tokens at once).
+                const chunkSize = cfg.streamTokens * 4;
+                const newText = available.length > chunkSize
+                    ? available.slice(0, chunkSize)
+                    : available;
+                cached.returnedChars += newText.length;
+
+                const cleaned = cleanupCompletion(newText);
+                if (cleaned.trim().length > 0) {
+                    if (cfg.logRequests) {
+                        output.appendLine(
+                            `[cache-hit] serving ${cleaned.length} cached chars (total buffered: ${cached.fullText.length - cached.returnedChars})`,
+                        );
+                    }
+                    return new vscode.InlineCompletionList([
+                        new vscode.InlineCompletionItem(
+                            cleaned,
+                            new vscode.Range(position, position),
+                        ),
+                    ]);
+                }
             }
 
-            const completion = await requestFim(apiKey, cfg, prefix, suffix, token);
-            if (!completion || token.isCancellationRequested) {
+            // 2) If a stream for this position is already in-flight, wait for
+            //    it to produce enough data instead of starting a duplicate.
+            const inflight = streamCache.get(cacheKey);
+            if (inflight && !inflight.isComplete && inflight.fullText.length === 0) {
+                // Wait for at least streamTokens worth of characters.
+                const streamCharTarget = cfg.streamTokens * 4;
+                const waitStart = Date.now();
+                while (
+                    inflight.fullText.length < streamCharTarget &&
+                    !inflight.isComplete &&
+                    Date.now() - waitStart < 2000 // safety timeout
+                ) {
+                    await sleep(50, token);
+                    if (token.isCancellationRequested) return undefined;
+                }
+
+                if (inflight.fullText.length > 0) {
+                    const toReturn = inflight.fullText.slice(inflight.returnedChars);
+                    inflight.returnedChars = inflight.fullText.length;
+                    const cleaned = cleanupCompletion(toReturn);
+                    if (cleaned.trim().length > 0) {
+                        return new vscode.InlineCompletionList([
+                            new vscode.InlineCompletionItem(
+                                cleaned,
+                                new vscode.Range(position, position),
+                            ),
+                        ]);
+                    }
+                }
+            }
+
+            // 3) No usable cache – start a fresh streaming request.
+            const result = await requestFimStream(
+                apiKey,
+                cfg,
+                prefix,
+                suffix,
+                cacheKey,
+                token,
+            );
+
+            if (!result || token.isCancellationRequested) {
                 return undefined;
             }
 
-            lastCacheKey = cacheKey;
-            lastCompletion = completion;
-
             return new vscode.InlineCompletionList([
-                new vscode.InlineCompletionItem(completion, new vscode.Range(position, position)),
+                new vscode.InlineCompletionItem(
+                    result.text,
+                    new vscode.Range(position, position),
+                ),
             ]);
         },
     };


### PR DESCRIPTION
Add smooth streaming UX to the FIM inline completion provider:

- New config: FIM.streamEnabled (default true), FIM.streamTokens (default 5), FIM.streamCacheTtlMs (default 30000)
- Early-return: requestFimStream() returns after ~streamTokens tokens arrive instead of waiting for the entire response, giving sub-200ms first display
- Background continuation: the remainder of the SSE stream is read in the background and buffered into a StreamCache for subsequent keystrokes
- Cache-first provider: findNearbyCacheEntry() searches cached streams at nearby offsets (±16 chars) so the next chunk is served instantly without an API call — creating a Copilot-like multi-step completion feel
- Chunked cache serving: even cached text is released in streamTokens-sized portions to maintain the smooth token-by-token rhythm
- In-flight deduplication: concurrent keystrokes for the same cache key wait on the existing stream instead of starting duplicates
- TTL eviction: stale cache entries (>30s idle) are cleaned every 10s
- Stream cache key: stable across small edits via hash of last 256 prefix chars, invalidated when immediate context changes meaningfully