### PR TITLE
docs: document streaming config in README, closes #2 and #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Example VS Code settings:
   "FIM.baseUrl": "https://api.deepseek.com/beta",
   "FIM.completionsPath": "/completions",
   "FIM.model": "deepseek-v4-flash",
-  "FIM.maxTokens": 144,
+  "FIM.maxTokens": 64,
   "FIM.temperature": 0.0,
   "FIM.topP": 0.9,
-  "FIM.prefixChars": 1000,
-  "FIM.suffixChars": 1000,
+  "FIM.prefixChars": 12000,
+  "FIM.suffixChars": 8000,
   "FIM.debounceMs": 150,
   "FIM.stop": [
       "\n\n",
@@ -63,8 +63,47 @@ Example VS Code settings:
        "\n  "
   ], // stop early to save tokens
   "FIM.withSuffix": true,
-  "FIM.logRequests": true // see timing in Output
+  "FIM.logRequests": true, // see timing in Output
+
+  // ── Streaming (smooth token-by-token UX) ──
+  "FIM.streamEnabled": true,
+  "FIM.streamTokens": 5,
+  "FIM.streamCacheTtlMs": 30000
 }
 ```
+
+## Streaming (Progressive Completion)
+
+The extension supports **progressive streaming** for a smooth, Copilot-like
+typing experience. Instead of waiting for the entire response, completions appear
+as soon as a few tokens arrive:
+
+| Setting | Default | Description |
+|---|---|---|
+| `FIM.streamEnabled` | `true` | Enable progressive streaming. When on, the extension returns after ~`streamTokens` tokens and continues reading the rest in the background. |
+| `FIM.streamTokens` | `5` | How many tokens to collect before showing the first chunk. Lower = faster first display, shorter initial suggestion. |
+| `FIM.streamCacheTtlMs` | `30000` | How long (in ms) to keep cached stream continuations. On the next keystroke the extension serves the next chunk from cache — **no API call needed**. |
+
+### How it works
+
+```
+API stream:  [tok1][tok2][tok3][tok4][tok5]...[tok64]
+                   ↑                        ↑
+          Return immediately        Continue in background,
+          (first chunk shown)       cache for next keystroke
+```
+
+1. **Early return** — after ~`streamTokens` tokens arrive (~20 chars), the
+   completion is shown immediately (typically <200ms).
+2. **Background continuation** — the rest of the SSE stream is read in the
+   background and buffered into an in-memory cache.
+3. **Cache-first serving** — on the next keystroke, if the context hasn't
+   changed meaningfully, the next chunk is served instantly from cache without
+   making a new API call. This creates a fluid *token-by-token* rhythm.
+4. **Nearby-offset lookup** — the cache searches ±16 character offsets so
+   small edits don't invalidate the buffered stream.
+
+To disable streaming and fall back to the original behaviour (wait for the
+full response), set `"FIM.streamEnabled": false`.
 
 Note: please disable other inline providers for best experience


### PR DESCRIPTION
Closes #2 — the progressive streaming feature (streamEnabled, streamTokens) gives a smooth token-by-token typing experience with early-return from SSE.

Closes #3 — the StreamCache with nearby-offset lookup and prefix-tail hashing reduces cache misses on consecutive keystrokes, serving continuations instantly without extra API calls.