### PR TITLE
fix: prevent linebreak truncation in completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ Example VS Code settings:
   "FIM.debounceMs": 150,
   "FIM.stop": [
       "\n\n",
-       "//",
-       "\n  "
-  ], // stop early to save tokens
+      "//"
+  ], // optional: stop early to save tokens (see note below)
   "FIM.withSuffix": true,
   "FIM.logRequests": true, // see timing in Output
 
@@ -107,3 +106,10 @@ To disable streaming and fall back to the original behaviour (wait for the
 full response), set `"FIM.streamEnabled": false`.
 
 Note: please disable other inline providers for best experience
+
+> **⚠️ Caution on `FIM.stop`:** Avoid patterns that match common code
+> structure. In particular **do not** use `"\\n  "` (newline + two spaces) —
+> it matches the start of *every* indented line and will truncate multi-line
+> completions. Stick to patterns that are unambiguous end-of-completion
+> signals like `"\\n\\n"` (blank line) or comment prefixes. When in doubt,
+> leave `FIM.stop` as `[]`.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,6 +384,7 @@ async function requestFimStream(
             ) {
                 earlyResolved = true;
                 const cleaned = cleanupCompletion(entry.fullText);
+                entry.fullText = cleaned;        // keep cache consistent with returnedChars
                 entry.returnedChars = cleaned.length;
 
                 // Return the first chunk NOW. The rest continues in background.


### PR DESCRIPTION
Two fixes:

1. Early-return cache sync: after cleanupCompletion() in the early-return path of requestFimStream(), now also sets entry.fullText = cleaned so that returnedChars stays in sync with the cached text.  Previously the cache could drift when cleanupCompletion modified the text (e.g. \r\n → \n normalisation), causing garbled chunk boundaries on subsequent cache hits.

2. README: removed the dangerous "\\n  " (newline + two spaces) stop sequence from the example configuration.  This pattern matches the start of every indented code line and caused the DeepSeek API to truncate completions immediately after entering any indented block — which is why multi-line completions appeared to be missing linebreaks.

   Added a caution block explaining why stop patterns must be chosen carefully.

Closes #6